### PR TITLE
Added compatibility with nette 2.2

### DIFF
--- a/Flame/Forms/FormProcessor.php
+++ b/Flame/Forms/FormProcessor.php
@@ -31,8 +31,9 @@ abstract class FormProcessor extends Object implements IFormProcessor
 
 	/**
 	 * @param Form $form
+	 * @param array|\Nette\Utils\ArrayHash|null $values
 	 */
-	public function success(Form $form) {}
+	public function success(Form $form, $values = null) {}
 
 	/**
 	 * @param Form $form

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
   "keywords": ["framework", "nette", "simple", "flame", "jsifalda", "tools"],
   "homepage": "https://github.com/flame-org/Form-Factory",
   "license": "BSD-2-Clause-FreeBSD",
-  "minimum-stability": "beta",
 
   "authors": [
     {
@@ -21,9 +20,9 @@
 
   "require": {
     "php": ">=5.3.2",
-    "nette/application": "~2.2-beta1",
-    "nette/forms": "~2.2-beta1",
-    "nette/di": "~2.2-beta1"
+    "nette/application": "~2.2",
+    "nette/forms": "~2.2",
+    "nette/di": "~2.2"
   },
 
   "config": {


### PR DESCRIPTION
Second argument for onSuccess, see https://github.com/nette/forms/blob/master/src/Forms/Form.php#L417-L419

But I'm not sure if second argument wouldn't be optional?
